### PR TITLE
Fix result-handle closing

### DIFF
--- a/src/Collection/LdapPaginatedIterator.php
+++ b/src/Collection/LdapPaginatedIterator.php
@@ -2,13 +2,20 @@
 
 namespace Laminas\Ldap\Collection;
 
+use Laminas\Ldap\ErrorHandler;
 use Laminas\Ldap\Exception\LdapException;
+use Laminas\Ldap\Handler;
 use Laminas\Ldap\Ldap;
 
 class LdapPaginatedIterator extends DefaultIterator {
+  /**
+   * Only used to free the ldap results when we deconstruct.
+   * @var []LDAP\Result
+   */
+  private $resultHandles;
 
   /** @noinspection PhpMissingParentConstructorInspection */
-  public function __construct(Ldap $ldap, $entries) {
+  public function __construct(Ldap $ldap, $entries, array $resultHandles) {
     if($entries == null){
       throw new LdapException($this->ldap, 'No entries given');
     }
@@ -18,6 +25,31 @@ class LdapPaginatedIterator extends DefaultIterator {
 
     $this->setSortFunction('strnatcasecmp');
     $this->itemCount = count($entries);
+    $this->resultHandles = $resultHandles;
   }
 
+  /**
+   * Called during deconstruction, overriding the implementation since we have several result handlers (per page)
+   * not just one.
+   *
+   * @override
+   * @return bool
+   */
+  public function close()
+  {
+    $isClosed = false;
+    foreach($this->resultHandles as $resultHandle) {
+      if ($resultHandle != null && Handler::isResultHandle($resultHandle)) {
+        ErrorHandler::start();
+        $isClosed       = ldap_free_result($resultHandle);
+        ErrorHandler::stop();
+
+        $this->current  = null;
+      }
+    }
+
+    $this->resultHandles = [];
+
+    return $isClosed;
+  }
 }


### PR DESCRIPTION
Re-implement how search results are freed to avoid NPEs

One cannot close the search result if we access the result-entries later, e.g.
by fetching the DN via key() or any other value - the result must stay
open even after an result-entry has been fetched via ldap_next_entry().
Every usage of ldap_get_dn/ldap_first_attribute/ldap_get_values_len required the result
set to be still open.

Since we have several result handles (several pages), we pass them all to the iterator 
which now care to free the ldap results in the deconstructor as best effort.